### PR TITLE
IK solver fix, Type issues 

### DIFF
--- a/robowflex_dart/include/robowflex_dart/structure.h
+++ b/robowflex_dart/include/robowflex_dart/structure.h
@@ -117,7 +117,6 @@ namespace robowflex
              */
             void dumpGraphViz(std::ostream &out, bool standalone = true);
 
-
             /** \} */
 
             /** \name Getting and Setting Configurations

--- a/robowflex_dart/scripts/fetch_se2.cpp
+++ b/robowflex_dart/scripts/fetch_se2.cpp
@@ -45,9 +45,9 @@ int main(int argc, char **argv)
     auto scene = std::make_shared<darts::Structure>("object");
     scene->addGround(-0.01, 10);
 
-    unsigned int nobs = 20;
+    size_t nobs = 20;
 
-    for (int i = 0; i < nobs; ++i)
+    for (size_t i = 0; i < nobs; ++i)
     {
         dart::dynamics::WeldJoint::Properties box_joint;
         box_joint.mName = log::format("box%1%", i);
@@ -56,8 +56,8 @@ int main(int argc, char **argv)
         scene->addWeldedFrame(box_joint, darts::makeBox(0.5, 0.5, 1));
     }
 
-    for (int i = 0; i < nobs; ++i)
-        for (int j = i + 1; j < nobs; ++j)
+    for (size_t i = 0; i < nobs; ++i)
+        for (size_t j = i + 1; j < nobs; ++j)
             scene->getACM()->disableCollision(log::format("box%1%", i), log::format("box%1%", j));
 
     world->addStructure(scene);

--- a/robowflex_library/include/robowflex_library/scene.h
+++ b/robowflex_library/include/robowflex_library/scene.h
@@ -163,7 +163,7 @@ namespace robowflex
 
         /** \brief Get a pose in the global frame relative to a collision object for grasping.
          *  \param[in] name Name of object to get pose for.
-         *  \param[in] offset The offset of the grasp.
+         *  \param[in] offset The offset of the grasp in the object's frame.
          *  \return Pose of the grasp offset from the object.
          */
         RobotPose getObjectGraspPose(const std::string &name, const RobotPose &offset) const;

--- a/robowflex_library/src/builder.cpp
+++ b/robowflex_library/src/builder.cpp
@@ -131,7 +131,15 @@ bool MotionRequestBuilder::setConfig(const std::string &requested_config)
 
     if (matches.empty())
     {
-        RBX_INFO("Could not find matching config for `%s`, setConfig failed", requested_config);
+        RBX_WARN("Could not find matching config for `%s`, setConfig failed", requested_config);
+        std::string valid_planners = "";
+        for (const auto &config : configs){
+            if (valid_planners.length() != 0){
+                valid_planners.append(", ");
+            }
+            valid_planners.append(config);
+        }
+        RBX_WARN("Valid Planners include: %s", valid_planners);
         return false;
     }
 

--- a/robowflex_library/src/builder.cpp
+++ b/robowflex_library/src/builder.cpp
@@ -130,7 +130,10 @@ bool MotionRequestBuilder::setConfig(const std::string &requested_config)
     }
 
     if (matches.empty())
+    {
+        RBX_INFO("Could not find matching config for `%s`, setConfig failed", requested_config);
         return false;
+    }
 
     const auto &found =
         std::min_element(matches.begin(), matches.end(),

--- a/robowflex_library/src/robot.cpp
+++ b/robowflex_library/src/robot.cpp
@@ -387,7 +387,12 @@ bool Robot::loadKinematics(const std::string &group_name, bool load_subgroups)
             std::find(groups.begin(), groups.end(), name) == groups.end())
         {
             RBX_ERROR("No JMG or Kinematics defined for `%s`!", name);
-            return false;
+            // return false;
+            // Instead of returning false, we continue to process additional
+            // joing groups. This is because while we don't have a 
+            // kinematics plugin for the base, we do have one for the 
+            // base and arm, so we should not stop here.
+            continue;
         }
 
         robot_model::JointModelGroup *jmg = model_->getJointModelGroup(name);
@@ -998,9 +1003,14 @@ robot_model::RobotStatePtr Robot::allocState() const
 std::vector<std::string> Robot::getSolverTipFrames(const std::string &group) const
 {
     const auto &jmg = model_->getJointModelGroup(group);
+    RBX_INFO("Getting tip frame for group %s", jmg->getName());
     const auto &solver = jmg->getSolverInstance();
     if (solver)
         return solver->getTipFrames();
+    else
+    {
+        RBX_WARN("Unable to get tip frame because unable to find solver instance");
+    }
 
     return {};
 }
@@ -1008,10 +1018,16 @@ std::vector<std::string> Robot::getSolverTipFrames(const std::string &group) con
 std::string Robot::getSolverBaseFrame(const std::string &group) const
 {
     const auto &jmg = model_->getJointModelGroup(group);
+    RBX_INFO("Getting base frame for group %s", jmg->getName());
     const auto &solver = jmg->getSolverInstance();
     if (solver)
+    {
         return solver->getBaseFrame();
-
+    }
+    else
+    {
+        RBX_WARN("Unable to get base frame because unable to find solver instance");
+    }
     return "";
 }
 

--- a/robowflex_library/src/scene.cpp
+++ b/robowflex_library/src/scene.cpp
@@ -288,11 +288,7 @@ RobotPose Scene::getObjectGraspPose(const std::string &name, const RobotPose &of
     if (not hasObject(name))
         throw Exception(1, log::format("Object `%1%` not in scene!", name));
 
-    const auto model = getSceneConst()->getRobotModel();
-    const auto rpose = getCurrentStateConst().getGlobalLinkTransform(model->getRootLinkName());
-    const auto opose = getObjectPose(name);
-
-    return rpose * opose * offset;
+    return getObjectPose(name) * offset;
 }
 
 bool Scene::moveAllObjectsGlobal(const RobotPose &transform)

--- a/robowflex_library/src/yaml.cpp
+++ b/robowflex_library/src/yaml.cpp
@@ -1258,7 +1258,8 @@ namespace YAML
 
     bool convert<ros::Duration>::decode(const Node &node, ros::Duration &rhs)
     {
-        if (node.Type() == NodeType::Scalar) {
+        if (node.Type() == NodeType::Scalar)
+        {
             rhs.fromSec(node.as<double>());
             return true;
         }

--- a/robowflex_visualization/robowflex_visualization/robot.py
+++ b/robowflex_visualization/robowflex_visualization/robot.py
@@ -273,7 +273,7 @@ class Robot:
                     self.set_joint_tf(name, tf, interpolate or i > 0)
                     self.add_keyframe(name, frame)
 
-        return last_frame
+        return math.ceil(last_frame)
 
     ## @brief Sets the robot's state from a file with a moveit_msgs::RobotState
     #

--- a/robowflex_visualization/robowflex_visualization/utils.py
+++ b/robowflex_visualization/robowflex_visualization/utils.py
@@ -354,7 +354,7 @@ def read_YAML_data(file_name):
         logging.warn('Cannot open {}'.format(file_name))
         return None
     with open(full_name) as input_file:
-        return yaml.load(input_file.read())
+        return yaml.load(input_file.read(), Loader=yaml.SafeLoader)
 
 
 def remove_doubles(item, threshold = 0.0001):


### PR DESCRIPTION
This is an update to the most recent version of my robowflex branch used for learn2plan.

Features include
---
- Fixed some type issues
- Continue parsing kinematics plugins even when previous links might not have an IK solver for them (this is useful when movable base itself might not have an IK solver, but arm+base does)
- Fixed a critical issue with IK when provided with an object query https://github.com/KavrakiLab/robowflex/pull/313